### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,6 @@ services:
     image: postgres:11.5-alpine
     container_name: postgres
     restart: unless-stopped
-    ports:
-      - "127.0.0:5432:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
     environment:
@@ -21,8 +19,6 @@ services:
     image: redis:5.0-alpine
     container_name: redis
     restart: on-failure
-    ports:
-      - 127.0.0.1:6379:6379
     volumes:
       - redis-data:/data
 


### PR DESCRIPTION
Removed external port for docker-containers. By default the ports should not be open. Especially if the server can be reached from the Internet. If you want to connect to these services from outside, you can go through an SSH tunnel if in doubt.