### PR TITLE
Remove journald as logging driver

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,8 +67,6 @@ services:
     depends_on:
       - postgres
       - redis
-    logging:
-      driver: journald
 
   scalelite-poller:
     image: ${SCALELITE_REPO:-blindsidenetwks}/scalelite:${SCALELITE_TAG:-v1}-poller
@@ -81,8 +79,6 @@ services:
       - postgres
       - redis
       - scalelite-api
-    logging:
-      driver: journald
 
   scalelite-recording-importer:
     image: ${SCALELITE_REPO:-blindsidenetwks}/scalelite:${SCALELITE_TAG:-v1}-recording-importer
@@ -98,5 +94,3 @@ services:
       - postgres
       - redis
       - scalelite-api
-    logging:
-      driver: journald


### PR DESCRIPTION
This makes it hard to run on a non-systemd distribution because there is no journald/journalctl.

Would this mean any regression? Is there a reason to use this specific logging driver?