### PR TITLE
Add non-interactive script options and fix nginx container name

### DIFF
--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -47,17 +47,16 @@ email="$LETSENCRYPT_EMAIL" # Adding a valid address is strongly recommended
 staging=${LETSENCRYPT_STAGING:-0} # Set to 1 if you're testing your setup to avoid hitting request limits
 
 if [ -d "$data_path" ]; then
-  if [ "$replaceExisting" -ne 0 ] && [ "$interactive" -eq 1 ]; then
+  if [ "$replaceExisting" -eq 0 ] && [ "$interactive" -eq 1 ]; then
     read -p "Existing data found for $domains. Continue and replace existing certificate? (y/N) " decision
     if [ "$decision" != "Y" ] && [ "$decision" != "y" ]; then
       exit
     fi
-  elif [ -z "$interactive" ]; then
+  elif [ "$interactive" -eq 0 ]; then
     echo "Certificates already exist."
     exit
   fi
 fi
-
 
 if [ ! -e "$data_path/conf/options-ssl-nginx.conf" ] || [ ! -e "$data_path/conf/ssl-dhparams.pem" ]; then
   echo "### Downloading recommended TLS parameters ..."

--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -10,8 +10,35 @@ if [[ ! -f ./.env ]]; then
   exit 1
 fi
 
+usage() {
+  echo -e "Initializes letsencrypt certificates for Nginx proxy container\n"
+  echo -e "Usage: $0 [-z|-r|-h]\n"
+  echo "  -n|--non-interactive  Enable non interactive mode"
+  echo "  -r|--replace          Replace existing certificates without asking"
+  echo "  -h|--help             Show usage information"
+  exit 1
+}
+
+interactive=1
+replaceExisting=0
+
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        -n|--non-interactive) interactive=0;shift;;
+        -r|--replace) replaceExisting=1;shift;;
+        -h|--help) usage;;
+        -*) echo "Unknown option: \"$1\"\n";usage;;
+        *) echo "Script does not accept arguments\n";usage;;
+    esac
+done
+
 URL_HOST=$(grep URL_HOST .env | cut -d '=' -f2)
 echo $URL_HOST
+NGINX_CONTAINER_NAME=$(grep DOCKER_PROXY_NGINX_TEMPLATE .env | cut -d '=' -f2)
+if [[ -z "$NGINX_CONTAINER_NAME" ]]; then
+  NGINX_CONTAINER_NAME=scalelite-proxy
+fi
 
 domains=($URL_HOST,redis.$URL_HOST)
 rsa_key_size=4096
@@ -20,8 +47,13 @@ email="$LETSENCRYPT_EMAIL" # Adding a valid address is strongly recommended
 staging=${LETSENCRYPT_STAGING:-0} # Set to 1 if you're testing your setup to avoid hitting request limits
 
 if [ -d "$data_path" ]; then
-  read -p "Existing data found for $domains. Continue and replace existing certificate? (y/N) " decision
-  if [ "$decision" != "Y" ] && [ "$decision" != "y" ]; then
+  if [ "$replaceExisting" -ne 0 ] && [ "$interactive" -eq 1 ]; then
+    read -p "Existing data found for $domains. Continue and replace existing certificate? (y/N) " decision
+    if [ "$decision" != "Y" ] && [ "$decision" != "y" ]; then
+      exit
+    fi
+  elif [ -z "$interactive" ]; then
+    echo "Certificates already exist."
     exit
   fi
 fi
@@ -46,8 +78,8 @@ docker-compose run --rm --entrypoint "\
 echo
 
 
-echo "### Starting scalelite-nginx ..."
-docker-compose up --force-recreate -d scalelite-nginx
+echo "### Starting $NGINX_CONTAINER_NAME ..."
+docker-compose up --force-recreate -d $NGINX_CONTAINER_NAME
 echo
 
 echo "### Deleting dummy certificate for $domains ..."
@@ -77,6 +109,7 @@ if [ $staging != "0" ]; then staging_arg="--staging"; fi
 docker-compose run --rm --entrypoint "\
   certbot certonly --webroot -w /var/www/certbot \
     $staging_arg \
+    $([ "$interactive" -ne 1 ] && echo '--non-interactive') \
     $email_arg \
     $domain_args \
     --rsa-key-size $rsa_key_size \
@@ -85,5 +118,5 @@ docker-compose run --rm --entrypoint "\
     --force-renewal" certbot
 echo
 
-echo "### Reloading scalelite-nginx ..."
-docker-compose exec scalelite-nginx nginx -s reload
+echo "### Reloading $NGINX_CONTAINER_NAME..."
+docker-compose exec $([ "$interactive" -ne 1 ] && echo "-T") $NGINX_CONTAINER_NAME nginx -s reload

--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -46,16 +46,16 @@ data_path="./data/certbot"
 email="$LETSENCRYPT_EMAIL" # Adding a valid address is strongly recommended
 staging=${LETSENCRYPT_STAGING:-0} # Set to 1 if you're testing your setup to avoid hitting request limits
 
-if [ -d "$data_path" ]; then
-  if [ "$replaceExisting" -eq 0 ] && [ "$interactive" -eq 1 ]; then
+if [ -d "$data_path" ] && [ "$replaceExisting" -eq 0 ]; then
+    if [ "$interactive" -eq 0 ]; then
+      echo "Certificates already exist."
+      exit
+    fi
+
     read -p "Existing data found for $domains. Continue and replace existing certificate? (y/N) " decision
     if [ "$decision" != "Y" ] && [ "$decision" != "y" ]; then
       exit
     fi
-  elif [ "$interactive" -eq 0 ]; then
-    echo "Certificates already exist."
-    exit
-  fi
 fi
 
 if [ ! -e "$data_path/conf/options-ssl-nginx.conf" ] || [ ! -e "$data_path/conf/ssl-dhparams.pem" ]; then


### PR DESCRIPTION
Hi Federico!

Figured out some thing to improve so I'll give it a go :)
This PR will introduce script options for non-interactive mode. It is useful when script is executed by crontab or from a non-interactive shell. When using non-interactive mode script will not ask for any user input.

Additionally, Nginx container name was hardcoded even though a different name was defined in docker-composer.yml. Script will now detect proper name from docker-compose file.