### PR TITLE
Fix URL_HOST & update doc

### DIFF
--- a/README-dev.md
+++ b/README-dev.md
@@ -31,7 +31,8 @@ Most required variables are preset by default, the ones that must be set before 
 ```
 SECRET_KEY_BASE=
 LOADBALANCER_SECRET=
-URL_HOST=
+SL_HOST=
+DOMAIN_NAME=
 ```
 
 Obtain the value for SECRET_KEY_BASE and LOADBALANCER_SECRET with:
@@ -41,17 +42,23 @@ sed -i "s/SECRET_KEY_BASE=.*/SECRET_KEY_BASE=$(openssl rand -hex 64)/" .env
 sed -i "s/LOADBALANCER_SECRET=.*/LOADBALANCER_SECRET=$(openssl rand -hex 24)/" .env
 ```
 
-Set the hostname on URL_HOST (E.g. sl.example.com)
+Set the hostname on SL_HOST (E.g. sl)
 
 ```
-sed -i "s/URL_HOST=.*/URL_HOST=sl.example.com" .env
+sed -i "s/SL_HOST=.*/SL_HOST=sl" .env
+```
+
+Set the domain name on DOMAIN_NAME (E.g. example.com)
+
+```
+sed -i "s/DOMAIN_NAME=.*/DOMAIN_NAME=example.com" .env
 ```
 
 ## Generate LetsEncrypt SSL certificates manually
 
 ```
 source ./.env
-certbot certonly --manual -d sl.$DOMAIN_NAME --agree-tos --no-bootstrap --manual-public-ip-logging-ok --preferred-challenges=dns --email <YOUR_ENMAIL> --server https://acme-v02.api.letsencrypt.org/director
+certbot certonly --manual -d $SL_HOST.$DOMAIN_NAME --agree-tos --no-bootstrap --manual-public-ip-logging-ok --preferred-challenges=dns --email <YOUR_ENMAIL> --server https://acme-v02.api.letsencrypt.org/director
 certbot certonly --manual -d redis.$DOMAIN_NAME --agree-tos --no-bootstrap --manual-public-ip-logging-ok --preferred-challenges=dns --email <YOUR_ENMAIL> --server https://acme-v02.api.letsencrypt.org/director
 ```
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Most required variables are pre-set by default, the ones that must be set before
 ```
 SECRET_KEY_BASE=
 LOADBALANCER_SECRET=
-URL_HOST=
+SL_HOST=
+DOMAIN_NAME=
 ```
 
 Obtain the value for SECRET_KEY_BASE and LOADBALANCER_SECRET with:
@@ -59,10 +60,16 @@ sed -i "s/SECRET_KEY_BASE=.*/SECRET_KEY_BASE=$(openssl rand -hex 64)/" .env
 sed -i "s/LOADBALANCER_SECRET=.*/LOADBALANCER_SECRET=$(openssl rand -hex 24)/" .env
 ```
 
-Set the hostname on URL_HOST (E.g. sl.example.com)
+Set the hostname on SL_HOST (E.g. sl)
 
 ```
-sed -i "s/URL_HOST=.*/URL_HOST=sl.example.com" .env
+sed -i "s/SL_HOST=.*/SL_HOST=sl" .env
+```
+
+Set the domain name on DOMAIN_NAME (E.g. example.com)
+
+```
+sed -i "s/DOMAIN_NAME=.*/DOMAIN_NAME=example.com" .env
 ```
 
 Start the services.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       - "80:80"
       - "443:443"
     environment:
-      - NGINX_HOSTNAME=${SL_HOST:-sl.xlab.blindside-ps.dev}
+      - NGINX_HOSTNAME=${SL_HOST:-sl}.${DOMAIN_NAME:-user.blindside-ps.dev}
     volumes:
       - ./log/proxy-nginx/:/var/log/nginx
       - ./data/proxy/nginx/sites.template.${DOCKER_PROXY_NGINX_TEMPLATE:-scalelite-proxy}:/etc/nginx/sites.template

--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -47,9 +47,10 @@ do
     esac
 done
 
-echo $URL_HOST
+domains="$SL_HOST.$DOMAIN_NAME"
 
-domains=($URL_HOST)
+echo $domains
+
 rsa_key_size=4096
 data_path="./data/certbot"
 email="$LETSENCRYPT_EMAIL" # Adding a valid address is strongly recommended.


### PR DESCRIPTION
This PR fixes the let's encrypt script and the nginx server name
Indeed, the $URL_HOST will not exists anymore and cause an issue when running the let's encrypt script to get the certificate.
For the NGINX_HOSTNAME env var, the simple fact to use the SL_HOST do not works because the server name will only contains the subdomain.